### PR TITLE
fix: Allow ShellTool in non-interactive mode via --allowed-tools

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1934,6 +1934,51 @@ describe('loadCliConfig tool exclusions', () => {
     expect(config.getExcludeTools()).not.toContain('replace');
     expect(config.getExcludeTools()).not.toContain('write_file');
   });
+
+  it('should not exclude shell tool in non-interactive mode when --allowed-tools="ShellTool" is set', async () => {
+    process.stdin.isTTY = false;
+    process.argv = [
+      'node',
+      'script.js',
+      '-p',
+      'test',
+      '--allowed-tools',
+      'ShellTool',
+    ];
+    const argv = await parseArguments({} as Settings);
+    const config = await loadCliConfig({}, [], 'test-session', argv);
+    expect(config.getExcludeTools()).not.toContain(ShellTool.Name);
+  });
+
+  it('should not exclude shell tool in non-interactive mode when --allowed-tools="run_shell_command" is set', async () => {
+    process.stdin.isTTY = false;
+    process.argv = [
+      'node',
+      'script.js',
+      '-p',
+      'test',
+      '--allowed-tools',
+      'run_shell_command',
+    ];
+    const argv = await parseArguments({} as Settings);
+    const config = await loadCliConfig({}, [], 'test-session', argv);
+    expect(config.getExcludeTools()).not.toContain(ShellTool.Name);
+  });
+
+  it('should not exclude shell tool in non-interactive mode when --allowed-tools="ShellTool(wc)" is set', async () => {
+    process.stdin.isTTY = false;
+    process.argv = [
+      'node',
+      'script.js',
+      '-p',
+      'test',
+      '--allowed-tools',
+      'ShellTool(wc)',
+    ];
+    const argv = await parseArguments({} as Settings);
+    const config = await loadCliConfig({}, [], 'test-session', argv);
+    expect(config.getExcludeTools()).not.toContain(ShellTool.Name);
+  });
 });
 
 describe('loadCliConfig interactive', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -32,6 +32,7 @@ import {
   ShellTool,
   EditTool,
   WriteFileTool,
+  SHELL_TOOL_NAMES,
 } from '@google/gemini-cli-core';
 import type { Settings } from './settings.js';
 
@@ -524,7 +525,9 @@ export async function loadCliConfig(
             if (t === ShellTool.Name) {
               // If any of the allowed tools is ShellTool (even with subcommands), don't exclude it.
               return !allowedTools.some((allowed) =>
-                allowed.startsWith(ShellTool.Name),
+                SHELL_TOOL_NAMES.some((shellName) =>
+                  allowed.startsWith(shellName),
+                ),
               );
             }
             return !allowedToolsSet.has(t);
@@ -538,7 +541,9 @@ export async function loadCliConfig(
             if (t === ShellTool.Name) {
               // If any of the allowed tools is ShellTool (even with subcommands), don't exclude it.
               return !allowedTools.some((allowed) =>
-                allowed.startsWith(ShellTool.Name),
+                SHELL_TOOL_NAMES.some((shellName) =>
+                  allowed.startsWith(shellName),
+                ),
               );
             }
             return !allowedToolsSet.has(t);


### PR DESCRIPTION
The `--allowed-tools` flag was not correctly identifying `ShellTool` and its aliases in non-interactive mode. This caused the tool to be excluded even when explicitly allowed.

This change fixes the issue by using `SHELL_TOOL_NAMES` to check for all valid names of the shell tool.

Adds unit tests to verify the fix.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
